### PR TITLE
Add a .gitignore for C++ projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app


### PR DESCRIPTION
This PR adds a `.gitignore` that uses [the standard GitHub template for C++ project](https://github.com/github/gitignore/blob/main/C%2B%2B.gitignore).

There are more things that could be added, including `*~` files and possibly other editor-specific files, but that can be done in follow-up PRs.