### PR TITLE
Add a `cpp-linter` workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,19 @@
+name: cpp-linter
+
+on: pull_request
+
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cpp-linter/cpp-linter-action@v2
+        #env:
+        #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          thread-comments: false
+          step-summary: false
+          file-annotations: true
+          style: 'llvm'
+          lines-changed-only: true  # switch to false once the whole repo is linted
+          files-changed-only: true  # same as above


### PR DESCRIPTION
This PR adds a workflow that runs cpp-linter on PRs.
Right now it only checks changed files/lines, but once the whole repo has been linted, it could be enabled for everything.
I commented out the `GITHUB_TOKEN` section, since it's not clear to me if it's needed.  If the workflow fails we'll have to set up a token.