### PR TITLE
Tournament fix

### DIFF
--- a/GA/HeaderFiles/Tournament.h
+++ b/GA/HeaderFiles/Tournament.h
@@ -23,7 +23,11 @@ extern int tournament_no;
 int Tournament(vector<float> fitness)
 {
   // Define starting parameters
-  int pool_size = 0.07 * population;
+  int pool_size = 2; //0.07 * population;
+  if (pool_size < 2)
+  {
+    pool_size = 2;
+  }
   vector<int> contenders;
   int random_num = 0;
   uniform_real_distribution<float> choice(0, fitness.size());

--- a/GA/HeaderFiles/Tournament.h
+++ b/GA/HeaderFiles/Tournament.h
@@ -2,9 +2,11 @@
 
 // Libraries
 #include <random>
+#include <algorithm>
 
 // Global Variables
 extern int seed;
+extern std::default_random_engine generator;
 extern int generation;
 extern int population;
 extern int sections;
@@ -27,10 +29,30 @@ int Tournament(vector<float> fitness)
   uniform_real_distribution<float> choice(0, fitness.size());
 
   // Select contenders for the tournament 
-  for (int i = 0; i < pool_size; i++)
+  // Don't allow for duplicates
+  int i = 0;
+  while (i < pool_size)
   {
-    random_num = rand() % fitness.size();
-    contenders.push_back(random_num);
+    // Choose random indvidual
+    random_num = choice(generator);
+
+    // If the list is empy add the individual
+    if (!contenders.empty())
+    {
+      contenders.push_back(random_num);
+      i = i + 1;
+    }
+    // If the list contains the individual, do not itterate
+    else if (find(contenders.begin(), contenders.end(), random_num) != contenders.end())
+    {
+      i = i;
+    }
+    // Otherwise add the individual to the list
+    else
+    {
+      contenders.push_back(random_num);
+      i = i + 1;
+    }
   }
 
   // Find the best individual from the contenders


### PR DESCRIPTION
(Ignore branch name nothing in crossover changes, the issue was in Tournament).
Essentially, I made the following changes to Tournament:

1. Changed the pool size to a fixed 2 individuals for now. 
2. Added fix that ensures Tournament does not have duplicate individuals in pools.

These were because, in runs that involved only Tournament selection, the GA was stalling in Crossover because there were not enough different individuals being selected to be able to finish crossover in later populations. We will need to revisit this later but for now these changes are fixing the problem in tests.